### PR TITLE
Fix rebundle naming issue in compilejs

### DIFF
--- a/gulp/compilejs.js
+++ b/gulp/compilejs.js
@@ -40,7 +40,7 @@ function watchjs(sources, outdir, outfile) {
 
   bundler.on('update', function() {
     gutil.log('recompiling js...');
-    rebundle(bundler);
+    rebundle_(bundler, outdir, outfile);
     gutil.log('finished recompiling js');
   });
   return rebundle_(bundler, outdir, outfile);


### PR DESCRIPTION
Function was inappopriately named "rebundle" instead of "rebundle_". As
well, it didn't pass the arguments through correctly.

Fixes #16