### PR TITLE
Implement scroll depth callback utility.

### DIFF
--- a/scrolldelegator/README.md
+++ b/scrolldelegator/README.md
@@ -1,0 +1,36 @@
+## scrolldelegator
+
+Utility functions for scrolling.
+
+### depth
+
+Calls a function whenever a scroll depth is reached. Typical use cases involve
+analytics tracking (e.g. to send analytics tracking events when users have
+reached a certain scroll depth.
+
+#### Sample usage
+
+```javascript
+// Generic example.
+var depth = require('airkit/scrolldelegator/depth');
+
+var callback = function(percentage, yPosition) {
+  console.log('Reached %: ', percentage);
+  console.log('Reached Y: ', yPosition);
+};
+
+depth.init(callback);
+```
+
+```javascript
+// Google Analytics Event Tracking example.
+var depth = require('airkit/scrolldelegator/depth');
+
+var track = function(percentage) {
+  var label = percentage + '%';
+  var value = percentage;
+  ga('send', 'event', ['Engagement'], ['Scroll Percentage'], [label], [value]);
+};
+
+depth.init(track);
+```

--- a/scrolldelegator/depth.js
+++ b/scrolldelegator/depth.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Calls a function whenever a scroll depth is reached.
+ * Ratio-based depths (e.g. 25%, 50%, 75%) are supported.
+ */
+
+var objects = require('../utils/objects');
+var scrolldelegator = require('.');
+
+
+var defaultConfig = {
+  ratios: [0.25, 0.50, 0.75, 0.95]
+};
+
+
+ScrollDepthCaller = function(cb, config) {
+  this.cb = cb;
+  this.ratios = config.ratios;
+  this.onScroll();
+};
+
+
+ScrollDepthCaller.prototype.onScroll = function() {
+  var yPos = scrolldelegator.getScrollPosY();
+  var scrollRatio = yPos / (document.body.offsetHeight - window.innerHeight);
+  for (var i = 0; i < this.ratios.length; i++) {
+    if (scrollRatio > this.ratios[i]) {
+      var percentage = this.ratios[i] * 100;
+      this.cb(percentage, yPos);
+      this.ratios[i] = 200;  // Ensure ratio isn't encountered again.
+    }
+  }
+};
+
+
+function init(cb, opt_config) {
+  var config = objects.clone(defaultConfig);
+  if (opt_config) {
+    objects.merge(config, opt_config);
+  }
+
+  var scrollDepthCaller = new ScrollDepthCaller(cb, config);
+  scrolldelegator.addDelegate(scrollDepthCaller);
+}
+
+
+module.exports = {
+  init: init
+};


### PR DESCRIPTION
Not sure if this is the best file location or name for this. Any other ideas? Not sure if I like `depth.init` but can't think of another good name for it right now...

This is a utility for callback functions for when certain scroll depths are reached. Many projects require us to track scroll depth (e.g. if a user has reached 25%, 50%, 75% of the page's content) and this utility makes that trivial (see the instructions in the README).