### PR TITLE
Expose modal constructor for cases in which you need multiple modals.

### DIFF
--- a/modal/index.js
+++ b/modal/index.js
@@ -241,5 +241,6 @@ function close() {
 module.exports = {
   init: init,
   openById: openById,
-  close: close
+  close: close,
+  Modal: Modal
 };


### PR DESCRIPTION
The Airkit Modal is a singleton in which the main Modal is not exposed publicly and instead, modals are constructed via the init function.  This is limiting for cases in which you want two different modals behaving in different ways on the same page (such as different transition time or different base class).

I would like to submit this change so that Modal constructor is exposed so that multiple instances can be manually created if needed.