### PR TITLE
Fix modal visibility duration

### DIFF
--- a/modal/index.js
+++ b/modal/index.js
@@ -165,10 +165,14 @@ Modal.prototype.setActive_ = function(active, opt_modalId, opt_updateState) {
     this.contentContainerEl.removeAttribute(activeAttr);
     var originalContainer = document.querySelector(
         '[data-' + this.config.className + '="' + activeId + '"]');
-    if (originalContainer) {
-      var currentContentEl = this.contentContainerEl.querySelector('div');
-      originalContainer.appendChild(currentContentEl);
-    }
+        
+    window.setTimeout(function() {
+      if (originalContainer) {
+        var currentContentEl = this.contentContainerEl.querySelector('div');
+        originalContainer.appendChild(currentContentEl);
+      }
+    }.bind(this), this.config.transitionDuration);
+
     this.config.onModalClose && this.config.onModalClose(activeId)
   }
 

--- a/modal/index.js
+++ b/modal/index.js
@@ -16,6 +16,7 @@ var defaultConfig = {
   history: true,
   historyNamePrefix: '',
   transitionDuration: 300,
+  visibilityDuration: 0,
   onModalOpen: null,
   onModalClose: null
 };
@@ -122,9 +123,11 @@ Modal.prototype.setVisible = function(enabled) {
   window.setTimeout(function() {
     classes.enable(lightboxEl, this.config.className + '--enabled', enabled);
   }.bind(this), enabled ? 0 : this.config.transitionDuration);
+
   window.setTimeout(function() {
     classes.enable(lightboxEl, this.config.className + '--visible', enabled);
-  }.bind(this), enabled ? this.config.transitionDuration : 0);
+  }.bind(this), enabled ? this.config.visibilityDuration ||
+    this.config.transitionDuration : 0);
 };
 
 


### PR DESCRIPTION
Change to address two issues with the modal.

1) The modal only adds 'xxx--visible' with a transitionDelay when opening the modal.  This is problematic for cases in which you want the visibilityDuration to be instant or different from the transitionDuration.

2) When closing the modal, the modal will actually remove the modal contents.  This is problematic in cases which you want to continue to show the modal contents during the exit animation.  Solution is to delay the content update.

