### PR TITLE
Modal improvements

### DIFF
--- a/modal/index.js
+++ b/modal/index.js
@@ -146,6 +146,7 @@ Modal.prototype.setActive_ = function(active, opt_modalId, opt_updateState) {
   var activeAttr = 'data-' + this.config.className + '-active-id';
   this.clearTimers_();
   if (active) {
+    this.returnContentToOrigin_();
 
     // Revert child node to original element which may exist if modal is
     // consecutively opened without first being closed.
@@ -166,22 +167,8 @@ Modal.prototype.setActive_ = function(active, opt_modalId, opt_updateState) {
     contentEl && this.contentContainerEl.appendChild(contentEl);
     this.config.onModalOpen && this.config.onModalOpen(opt_modalId)
   } else {
-    var activeId = this.contentContainerEl.getAttribute(activeAttr);
-    this.contentContainerEl.removeAttribute(activeAttr);
-    var originalContainer = document.querySelector(
-        '[data-' + this.config.className + '="' + activeId + '"]');
-
-    var timer = window.setTimeout(function() {
-      if (originalContainer) {
-        var currentContentEl = this.contentContainerEl.querySelector('div');
-        currentContentEl && originalContainer.appendChild(currentContentEl);
-      }
-    }.bind(this), this.config.transitionDuration);
-    this.timers_.push(timer);
-
     this.config.onModalClose && this.config.onModalClose(activeId)
   }
-
   this.setVisible(active);
   if (!this.config.history || opt_updateState === false) {
     return;
@@ -202,6 +189,27 @@ Modal.prototype.setActive_ = function(active, opt_modalId, opt_updateState) {
         {'akModalId': null}, '', window.location.pathname);
   }
 };
+
+
+/**
+ * Reverts modal contents back to it's original element.
+ * @private
+ */
+Modal.prototype.returnContentToOrigin_ = function() {
+  if(!this.contentContainerEl) {
+    return;
+  }
+  var activeAttr = 'data-' + this.config.className + '-active-id';
+  var activeId = this.contentContainerEl.getAttribute(activeAttr);
+  this.contentContainerEl.removeAttribute(activeAttr);
+  var originalContainer = document.querySelector(
+      '[data-' + this.config.className + '="' + activeId + '"]');
+
+  if (originalContainer) {
+    var currentContentEl = this.contentContainerEl.querySelector('div');
+    currentContentEl && originalContainer.appendChild(currentContentEl);
+  }
+}
 
 
 /**


### PR DESCRIPTION
A few fixes that I noticed while working on a modal with a longer transition.

Problem: With longer transition durations, quickly opening/closing the modal caused instability.
Solution: Clear timeouts.

Problem: On close, the modal attempts to reappend the modal contents back to it's originating div.  This causes issues during longer transitions.
Solution: Wait to reappend the contents until the modal needs to open again.