### PR TITLE
Add enter and exit classes to root element for additional transition

### DIFF
--- a/modal/index.js
+++ b/modal/index.js
@@ -126,14 +126,14 @@ Modal.prototype.setVisible = function(enabled) {
   var enterClass = this.config.className + '--enter';
   var exitClass = this.config.className + '--exit';
   window.setTimeout(function() {
-    if(enabled) {
+    if (enabled) {
       lightboxEl.classList.remove(exitClass);
       lightboxEl.classList.add(enterClass);
     } else {
       lightboxEl.classList.remove(enterClass);
       lightboxEl.classList.add(exitClass);
     }
-  });
+  }, 0);
 
   var enableTimer = window.setTimeout(function() {
     classes.enable(lightboxEl, this.config.className + '--enabled', enabled);

--- a/modal/index.js
+++ b/modal/index.js
@@ -122,6 +122,19 @@ Modal.prototype.setVisible = function(enabled) {
   }
 
   var lightboxEl = document.querySelector('.' + this.config.className);
+
+  var enterClass = this.config.className + '--enter';
+  var exitClass = this.config.className + '--exit';
+  window.setTimeout(function() {
+    if(enabled) {
+      lightboxEl.classList.remove(exitClass);
+      lightboxEl.classList.add(enterClass);
+    } else {
+      lightboxEl.classList.remove(enterClass);
+      lightboxEl.classList.add(exitClass);
+    }
+  });
+
   var enableTimer = window.setTimeout(function() {
     classes.enable(lightboxEl, this.config.className + '--enabled', enabled);
   }.bind(this), enabled ? 0 : this.config.transitionDuration);


### PR DESCRIPTION
I have a usecase in which I want to add slightly different animations for when the modal opens and closes.

This is a quick change to add ak-modal--enter and ak-modal--exit on the root modal element.