### PR TITLE
Use the first hash if a nested hash is passed in modal.

### DIFF
--- a/modal/index.js
+++ b/modal/index.js
@@ -62,8 +62,22 @@ Modal.prototype.hideModalElements_ = function() {
 };
 
 
+/**
+ * Gets the first hash value in a string.
+ * For example #modal-id#deep-link-within-modal. In this event, return the
+ * first hash.
+ */
+Modal.prototype.getFirstHash_ = function(hash) {
+  if (hash.includes('#')) {
+    hash = hash.split('#')[0];
+  }
+  return hash;
+}
+
+
 Modal.prototype.initStateFromHash_ = function() {
-  var idFromHash = window.location.hash.substr(1);
+  var idFromHash = this.getFirstHash_(window.location.hash.substr(1));
+
   if (this.isValidModalId_(idFromHash)) {
     this.setActive_(true, idFromHash, false);
   }


### PR DESCRIPTION
I have a case in which, the contents of my modal are a giant page.  I need to be able to deep link to contents within the ak-modal.  The deep link logic I am handling with the onOpen callbacks but I need ak-modal to work with nested hash paramers.

Example:  mysite.com/home.html#mymodal#mydeeplinkwithinmodal.