### PR TITLE
Fix typos in function calls

### DIFF
--- a/analytics/tracking.js
+++ b/analytics/tracking.js
@@ -124,9 +124,9 @@ Tracker.prototype.getTrackingObject = function(el) {
   var obj = new TrackingObject();
   obj.attrs = this.parseAttrs_(el);
   obj.element = el;
-  obj.label = this.getLabel_(el);
+  obj.label = this.getLabel(el);
   obj.linkCategory = this.getLinkCategory_(el);
-  obj.linkCategoryName = this.getNameForLinkCategory_(obj.linkCategory);
+  obj.linkCategoryName = this.getNameForLinkCategory(obj.linkCategory);
   return obj;
 };
 


### PR DESCRIPTION
There were a couple typos that were causing the tracking code to throw errors, which I've fixed. I removed underscores that were incorrect, but maybe it would be better to add underscores to the function names instead?