### PR TITLE
Force autoplay in mobile youtubemodal

### DIFF
--- a/youtubemodal/index.js
+++ b/youtubemodal/index.js
@@ -249,7 +249,13 @@ YouTubeModal.prototype.play = function(videoId, opt_updateState, opt_startTime, 
 
   var options = {
     'videoId': videoId,
-    'playerVars': playerVars
+    'playerVars': playerVars,
+    'events': {
+      // Need to do this to force autoplay on mobile
+      'onReady': function(event) {
+        event.target.playVideo();
+      },
+    },
   };
   player = new YT.Player(playerEl, options);
   this.activeVideoId_ = videoId;


### PR DESCRIPTION
This changes affects cases where  `useHandlerOnMobile` is set to false.

Even with the `autoplay` param set, the video would not play on mobile browsers until the user clicked "play" again. We get around this by using a callback that fires when the video is ready to play, and then playing it.

See https://developers.google.com/youtube/iframe_api_reference#Example_Video_Player_Constructors