### PR TITLE
Bugfix: `opt_startTime` ignored after first play

### DIFF
--- a/youtubemodal/index.js
+++ b/youtubemodal/index.js
@@ -276,7 +276,11 @@ YouTubeModal.prototype.play = function(videoId, opt_updateState, opt_startTime, 
   if (player && videoId == this.activeVideoId_) {
     return;
   } else if (player && videoId != this.activeVideoId_) {
-    player.loadVideoById(videoId, 0, 'large');
+    var startTime = 0;
+    if (opt_startTime) {
+      startTime = opt_startTime;
+    }
+    player.loadVideoById(videoId, startTime, 'large');
     this.activeVideoId_ = videoId;
     return;
   }


### PR DESCRIPTION
player.loadVideoById() was always being run with zero seconds. This change uses the value of `opt_startTime` if provided.