### PR TITLE
Make scroll-on-close optional

### DIFF
--- a/modal/index.js
+++ b/modal/index.js
@@ -19,7 +19,8 @@ var defaultConfig = {
   transitionDuration: 300,
   visibilityDuration: 0,
   onModalOpen: null,
-  onModalClose: null
+  onModalClose: null,
+  setScrollOnClose: true,
 };
 
 
@@ -162,7 +163,9 @@ Modal.prototype.setVisible = function(enabled) {
     } else {
       lightboxEl.classList.remove(enterClass);
       lightboxEl.classList.add(exitClass);
-      window.scrollTo(0, this.scrollY);
+      if (this.config.setScrollOnClose) {
+        window.scrollTo(0, this.scrollY);
+      }
     }
   }, 0);
 


### PR DESCRIPTION
This functionality does not work for my needs and I'd like to override the scrolling functionality in an onModalClose() function. In order to do this, I need to be able to prevent the default scrolling behaviour, so I've added a boolean to the default config `setScrollOnClose`, which is true by default.